### PR TITLE
Let CoreUIKit OfferDetails grow beyond anchor

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,10 @@ var viewer = bootstrapper.createViewer(data, {
 });
 ```
 
+### Version N.E.X.T
+
+- Let CoreUIKit OfferDetails grow beyond the width of its anchor, with respect to on-screen position.
+
 ### Version 3.0.0
 
 - _BREAKING INCITO CHANGE_ Now, you need to supply the identifier of the publication rather than the Incito identifier. Plus, we've added a new event to measure how many times Incito's are opened. Anonymously.

--- a/lib/coffeescript/kits/core-ui/offer-details.coffee
+++ b/lib/coffeescript/kits/core-ui/offer-details.coffee
@@ -1,10 +1,14 @@
 module.exports = class OfferDetails
-    constructor: (@options = {}) ->
+    constructor: ({ @minWidth = 300, @maxWidth = "100vw", @anchorEl, @contentEl }) ->
+        @elInner = document.createElement 'div'
+        @elInner.className = 'sgn-offer-details-inner'
+
         @el = document.createElement 'div'
 
         @el.className = 'sgn-offer-details'
         @el.setAttribute 'tabindex', -1
-        @el.appendChild @options.contentEl
+        @el.appendChild @elInner
+        @el.appendChild @contentEl
 
         @position()
 
@@ -34,14 +38,34 @@ module.exports = class OfferDetails
         return
     
     position: ->
-        rect = @options.anchorEl.getBoundingClientRect()
-        top = window.pageYOffset + rect.top + @options.anchorEl.offsetHeight
+        rect = @anchorEl.getBoundingClientRect()
+        top = window.pageYOffset + rect.top + @anchorEl.offsetHeight
         left = window.pageXOffset + rect.left
-        width = @options.anchorEl.offsetWidth
-
+        width = @anchorEl.offsetWidth
+        
         @el.style.top = top + 'px'
-        @el.style.left = left + 'px'
-        @el.style.width = width + 'px'
+
+        rightAligned = rect.left >= (window.outerWidth / 2)
+        left = window.pageXOffset + rect.left
+        right = window.pageXOffset + (window.outerWidth - rect.right)
+
+        if rightAligned
+            @el.style.left = 'auto'
+            @el.style.right = right + 'px'
+
+            @elInner.style.left = 'auto'
+            @elInner.style.right = 0
+        else
+            @el.style.left = left + 'px'
+            @el.style.right = 'auto'
+
+            @elInner.style.left = 0
+            @elInner.style.right = 'auto'
+
+        @el.style.minWidth = if typeof @minWidth == 'number' then Math.max(width, @minWidth) + 'px' else @minWidth
+        @el.style.maxWidth = @maxWidth
+
+        @elInner.style.width = (width - 8) + 'px'
 
         return
     

--- a/lib/coffeescript/kits/core-ui/offer-details.coffee
+++ b/lib/coffeescript/kits/core-ui/offer-details.coffee
@@ -1,5 +1,5 @@
 module.exports = class OfferDetails
-    constructor: ({ @minWidth = 300, @maxWidth = "100vw", @anchorEl, @contentEl }) ->
+    constructor: ({@minWidth = 300, @maxWidth = '100vw', @anchorEl, @contentEl}) ->
         @elInner = document.createElement 'div'
         @elInner.className = 'sgn-offer-details-inner'
 

--- a/lib/stylus/kits/core-ui/offer-details.styl
+++ b/lib/stylus/kits/core-ui/offer-details.styl
@@ -1,10 +1,11 @@
 .sgn-offer-details
-    absolute top left
+    absolute top
     z-index 10
     background-color #fff
     border-left 4px solid rgba(#000, 0.8)
     border-right 4px solid rgba(#000, 0.8)
     border-bottom 4px solid rgba(#000, 0.8)
+    border-top 4px solid rgba(#000, 0.8)
     border-radius bottom left 10px
     border-radius bottom right 10px
     padding 10px
@@ -14,6 +15,12 @@
     outline 0
     box-sizing border-box
 
+    & > &-inner 
+        background #fff
+        height 4px
+        top -4px
+        position absolute
+    
     &.in
         opacity 1
         transform translateY(0px) scale(1)


### PR DESCRIPTION
Let CoreUIKit OfferDetails grow beyond the width of its anchor, with respect to on-screen position.

Also adds options to the `OfferDetails` constructor to allow fine-tuning positioning:
`minWidth`: Default `300px` or `anchorEl` width, whichever is larger(so `OfferDetails` will never be narrower than `anchorEl`)
 `maxWidth`: Default `100vw`

Motivation: https://3.basecamp.com/4286639/buckets/13812214/todos/2144440834