### PR TITLE
PagedPublicationKit: Desktop high res page images

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ To learn more about integrating the same experience on iOS and Android be sure t
 
 ## Changelog
 
+### Version N.E.X.T
+
+- PagedPublicationKit: Will now use zoom-size images for pages prior to zooming in, when the physical pixel width of the page would be presented as over 700 pixels wide.
+
 ### Version 3.1.1
 
 - IncitoPublicationKit: Removed sessionStorage caching due to excessive JSON.parse JSON.stringify operations, which slows down the browser.

--- a/lib/coffeescript/kits/paged-publication/page-spread.coffee
+++ b/lib/coffeescript/kits/paged-publication/page-spread.coffee
@@ -41,7 +41,14 @@ class PagedPublicationPageSpread
         imageLoads = 0
 
         pages.forEach (page, i) =>
+            maxPageWidth = el.clientWidth * (window.devicePixelRatio or 1)
+            if @options.pageMode is "double"
+                maxPageWidth = maxPageWidth / 2
+
             image = page.images.medium
+            if maxPageWidth > 700
+                image = page.images.large
+
             pageEl = document.createElement 'div'
             loaderEl = document.createElement 'div'
 

--- a/lib/coffeescript/kits/paged-publication/page-spread.coffee
+++ b/lib/coffeescript/kits/paged-publication/page-spread.coffee
@@ -40,13 +40,15 @@ class PagedPublicationPageSpread
         pageCount = pages.length
         imageLoads = 0
 
-        pages.forEach (page, i) =>
-            maxPageWidth = el.clientWidth * (window.devicePixelRatio or 1)
-            if @options.pageMode is "double"
-                maxPageWidth = maxPageWidth / 2
+        maxPageWidth = el.clientWidth * (window.devicePixelRatio or 1)
+        if @options.pageMode is "double"
+            maxPageWidth = maxPageWidth / 2
 
+        useLargeImage = maxPageWidth > 700
+
+        pages.forEach (page, i) =>
             image = page.images.medium
-            if maxPageWidth > 700
+            if useLargeImage
                 image = page.images.large
 
             pageEl = document.createElement 'div'

--- a/lib/coffeescript/kits/paged-publication/page-spreads.coffee
+++ b/lib/coffeescript/kits/paged-publication/page-spreads.coffee
@@ -41,6 +41,7 @@ class PagedPublicationPageSpreads
             id = "#{pageMode}-#{i}"
             pageSpread = new PageSpread
                 width: width
+                pageMode: pageMode
                 maxZoomScale: maxZoomScale
                 pages: pages
                 id: id


### PR DESCRIPTION
PagedPublicationKit will now use zoom-res images for pages prior to zooming in, when the physical pixel width of the page would be over 700 pixels wide.