### PR TITLE
Use MicroEvent in incito-browser

### DIFF
--- a/lib/incito-browser/incito.js
+++ b/lib/incito-browser/incito.js
@@ -1,3 +1,4 @@
+import MicroEvent from 'microevent';
 import './incito.styl';
 import {isDefinedStr, throttle} from './utils';
 import * as views from './views';
@@ -32,7 +33,7 @@ const syncIdleCallback = function (cb) {
     });
 };
 
-export default class Incito {
+export default class Incito extends MicroEvent {
     constructor(
         containerEl,
         {
@@ -40,6 +41,7 @@ export default class Incito {
             renderLaziness = 1 // 0: All synchronous. 1: Visible synchronous, rest lazy. 2: All lazy.
         }
     ) {
+        super();
         this.containerEl = containerEl;
         this.incito = incito;
         this.renderLaziness = renderLaziness;
@@ -51,29 +53,6 @@ export default class Incito {
         this.lazyloadables = [];
         this.lazyloader = throttle(this.lazyload.bind(this), 150);
         this.renderedOutsideOfViewport = false;
-        this._events = {};
-    }
-
-    bind(event, fn) {
-        this._events[event] = this._events[event] || [];
-        return this._events[event].push(fn);
-    }
-
-    unbind(event, fn) {
-        if (this._events[event]) {
-            return this._events[event].splice(
-                this._events[event].indexOf(fn),
-                1
-            );
-        }
-    }
-
-    trigger(event) {
-        if (this._events[event]) {
-            return this._events[event].map(function (e) {
-                return e.apply(this, Array.prototype.slice.call(arguments, 1));
-            });
-        }
     }
 
     start() {


### PR DESCRIPTION
This PR is mostly here to test tests and `compressed-size-action`.

Expected changes is a size reduction in packages that use `incito-browser` along other `MicroEvent` subclasses but a slight increase in the `incito-browser` package itself.