### PR TITLE
feat: add html-view to incito-browser

### DIFF
--- a/lib/incito-browser/views/html-view.js
+++ b/lib/incito-browser/views/html-view.js
@@ -1,0 +1,53 @@
+import {isDefinedStr} from '../utils';
+import './html-view.styl';
+import View from './view';
+
+
+class HTMLView extends View {
+    render() {
+        if (isDefinedStr(this.attrs.style)) {
+            this.el.style = this.attrs.style;
+        }
+
+        if (isDefinedStr(this.attrs.text)) {
+            this.el.innerText = this.attrs.text;
+        }
+
+        if (isDefinedStr(this.attrs.src)) {
+            this.el.src = this.attrs.src;
+        }
+
+        if (this.attrs.dataset) {
+            for (const id in this.attrs.dataset) {
+                this.el.setAttribute(`data-${id}`, this.attrs.dataset[id]);
+            }
+        }
+
+        if (isDefinedStr(this.attrs.class)) {
+            this.el.className += ' ' + this.attrs.class;
+        }
+
+        return this;
+    }
+
+    createElement() {
+        let tagName = 'div';
+
+        if (isDefinedStr(this.attrs.tag_name)) {
+            tagName = this.attrs.tag_name;
+        } else if (isDefinedStr(this.attrs.text)) {
+            tagName = 'p';
+        } else if (isDefinedStr(this.attrs.src)) {
+            tagName = 'img';
+        }
+
+        const el = document.createElement(tagName);
+
+        el.className = 'incito__view incito__html-view';
+
+        return el;
+    }
+
+}
+
+export default HTMLView;

--- a/lib/incito-browser/views/html-view.js
+++ b/lib/incito-browser/views/html-view.js
@@ -1,5 +1,4 @@
 import {isDefinedStr} from '../utils';
-import './html-view.styl';
 import View from './view';
 
 class HTMLView extends View {

--- a/lib/incito-browser/views/html-view.js
+++ b/lib/incito-browser/views/html-view.js
@@ -9,45 +9,10 @@ class HTMLView extends View {
             this.el.style = this.attrs.style;
         }
 
-        if (isDefinedStr(this.attrs.text)) {
-            this.el.innerText = this.attrs.text;
-        }
-
-        if (isDefinedStr(this.attrs.src)) {
-            this.el.src = this.attrs.src;
-        }
-
-        if (this.attrs.dataset) {
-            for (const id in this.attrs.dataset) {
-                this.el.setAttribute(`data-${id}`, this.attrs.dataset[id]);
-            }
-        }
-
-        if (isDefinedStr(this.attrs.class)) {
-            this.el.className += ' ' + this.attrs.class;
-        }
-
         return this;
     }
-
-    createElement() {
-        let tagName = 'div';
-
-        if (isDefinedStr(this.attrs.tag_name)) {
-            tagName = this.attrs.tag_name;
-        } else if (isDefinedStr(this.attrs.text)) {
-            tagName = 'p';
-        } else if (isDefinedStr(this.attrs.src)) {
-            tagName = 'img';
-        }
-
-        const el = document.createElement(tagName);
-
-        el.className = 'incito__view incito__html-view';
-
-        return el;
-    }
-
 }
 
+HTMLView.prototype.tagName = 'div';
+HTMLView.prototype.className = 'incito__html-view';
 export default HTMLView;

--- a/lib/incito-browser/views/html-view.js
+++ b/lib/incito-browser/views/html-view.js
@@ -2,7 +2,6 @@ import {isDefinedStr} from '../utils';
 import './html-view.styl';
 import View from './view';
 
-
 class HTMLView extends View {
     render() {
         if (isDefinedStr(this.attrs.style)) {

--- a/lib/incito-browser/views/html-view.styl
+++ b/lib/incito-browser/views/html-view.styl
@@ -1,0 +1,2 @@
+.incito__html-view
+  margin: 0

--- a/lib/incito-browser/views/html-view.styl
+++ b/lib/incito-browser/views/html-view.styl
@@ -1,1 +1,0 @@
-.incito__html-view

--- a/lib/incito-browser/views/html-view.styl
+++ b/lib/incito-browser/views/html-view.styl
@@ -1,2 +1,1 @@
 .incito__html-view
-  margin: 0

--- a/lib/incito-browser/views/index.js
+++ b/lib/incito-browser/views/index.js
@@ -5,3 +5,4 @@ export {default as TextView} from './text';
 export {default as VideoView} from './video';
 export {default as VideoEmbedView} from './video-embed';
 export {default as View} from './view';
+export {default as HTMLView} from './html-view';


### PR DESCRIPTION
This PR adds support for a basic `HTMLView` into the `incito-browser` library, which supports an additional style property that allows the use of valid CSS style syntax.

By default an `HTMLView` is a `div` element with custom style properties.