### PR TITLE
Add appKey config requirement in CoreKit.request

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ When installed you can require and configure the SDK:
 SGN = require('sgn-sdk');
 
 SGN.config.set({
-    appKey: 'YOUR_APP_KEY'
+    apiKey: 'YOUR_API_KEY'
 });
 ```
 
@@ -55,7 +55,7 @@ We recommend using environment variables for the config to avoid having secrets 
 
 ```javascript
 SGN.config.set({
-    appKey: process.env.SHOPGUN_APP_KEY
+    apiKey: process.env.SHOPGUN_API_KEY
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The SDK makes use of both JavaScript and CSS so you need to load two resources i
 <script
     src="https://d21oefkcnoen8i.cloudfront.net/sgn-sdk-3.4.0.min.js"
     id="sgn-sdk"
-    data-app-key="YOUR_APP_KEY"
+    data-api-key="YOUR_API_KEY"
     data-track-id="YOUR_TRACK_ID"
 ></script>
 ```

--- a/__tests__/chrome/sgn.test-chrome.html
+++ b/__tests__/chrome/sgn.test-chrome.html
@@ -4,7 +4,7 @@
         <script
             src="../../dist/shopgun-sdk/sgn-sdk.js"
             id="sgn-sdk"
-            data-app-key="00j4o5wpwptl84fuubdig2s6ej5uyna8"
+            data-api-key="00j4o5wpwptl84fuubdig2s6ej5uyna8"
             data-track-id="AAABrQ=="
         ></script>
     </body>

--- a/__tests__/chrome/sgn.test-chrome.js
+++ b/__tests__/chrome/sgn.test-chrome.js
@@ -18,7 +18,7 @@ describe('Chrome: SGN singleton behavior', () => {
     });
     it('Magic API key config from script tag', async () => {
         const srcAppKey = await page.evaluate(
-            () => document.querySelector('[data-app-key]').dataset.appKey
+            () => document.querySelector('[data-api-key]').dataset.apiKey
         );
         const cfgAppKey = await page.evaluate(() =>
             window.SGN.config.get('appKey')

--- a/__tests__/core_kit.test.js
+++ b/__tests__/core_kit.test.js
@@ -1,8 +1,8 @@
 const SGN = require('../');
-const appKey = '00j4o5wpwptl84fuubdig2s6ej5uyna8';
+const apiKey = '00j4o5wpwptl84fuubdig2s6ej5uyna8';
 
 SGN.config.set({
-    appKey
+    apiKey
 });
 
 describe('SGN.CoreKit', () => {

--- a/docs/incito.md
+++ b/docs/incito.md
@@ -26,7 +26,7 @@ You may choose to either include the project from `npm` _or_ use our CloudFront 
 
     ```JS
     const shopgunAppConfig = {
-        apiKey: 'YOUR_APP_KEY',
+        apiKey: 'YOUR_API_KEY',
         eventTracker: new SGN.EventsKit.Tracker(trackId: 'YOUR_TRACK_ID')
     };
 
@@ -40,7 +40,7 @@ You may choose to either include the project from `npm` _or_ use our CloudFront 
     ```HTML
     <link href="https://d21oefkcnoen8i.cloudfront.net/sgn-sdk-3.3.0.min.css" rel='stylesheet' />
 
-    <script src="https://d21oefkcnoen8i.cloudfront.net/sgn-sdk-3.3.0.min.js" id="sgn-sdk" data-app-key="YOUR_APP_KEY" data-track-id="YOUR_TRACK_ID"></script>
+    <script src="https://d21oefkcnoen8i.cloudfront.net/sgn-sdk-3.3.0.min.js" id="sgn-sdk" data-api-key="YOUR_APP_KEY" data-track-id="YOUR_TRACK_ID"></script>
     ```
 
     You may use our distribution or choose to host the code yourself. Should you choose to use our distribution remember to point to the latest working version.

--- a/docs/incito.md
+++ b/docs/incito.md
@@ -26,7 +26,7 @@ You may choose to either include the project from `npm` _or_ use our CloudFront 
 
     ```JS
     const shopgunAppConfig = {
-        appKey: 'YOUR_APP_KEY',
+        apiKey: 'YOUR_APP_KEY',
         eventTracker: new SGN.EventsKit.Tracker(trackId: 'YOUR_TRACK_ID')
     };
 

--- a/examples/incito-publication.html
+++ b/examples/incito-publication.html
@@ -38,7 +38,7 @@
         <script
             src="../dist/shopgun-sdk/sgn-sdk.js"
             id="sgn-sdk"
-            data-app-key="00j4o5wpwptl84fuubdig2s6ej5uyna8"
+            data-api-key="00j4o5wpwptl84fuubdig2s6ej5uyna8"
             data-track-id="AAABrQ=="
         ></script>
         <script>

--- a/examples/paged-publication.html
+++ b/examples/paged-publication.html
@@ -401,7 +401,7 @@
         <script
             src="../dist/shopgun-sdk/sgn-sdk.js?t=3"
             id="sgn-sdk"
-            data-app-key="00j4o5wpwptl84fuubdig2s6ej5uyna8"
+            data-api-key="00j4o5wpwptl84fuubdig2s6ej5uyna8"
             data-track-id="AAABrQ=="
         ></script>
         <script src="js/paged-publication.js"></script>

--- a/lib/config.js
+++ b/lib/config.js
@@ -2,15 +2,16 @@ import MicroEvent from 'microevent';
 import * as configDefaults from './config-defaults';
 
 class Config extends MicroEvent {
-    attrs = {...configDefaults};
+    #attrs = {...configDefaults};
 
     set(config = {}) {
         const changedAttributes = {};
 
         for (let key in config) {
+            if (key === 'appKey') key = 'apiKey';
             const value = config[key];
             if (this.keys.includes(key)) {
-                this.attrs[key] = value;
+                this.#attrs[key] = value;
                 changedAttributes[key] = value;
             }
         }
@@ -19,12 +20,13 @@ class Config extends MicroEvent {
     }
 
     get(option) {
-        return this.attrs[option];
+        if (option === 'appKey') option = 'apiKey';
+        return this.#attrs[option];
     }
 }
 Config.prototype.keys = [
     'appVersion',
-    'appKey',
+    'apiKey',
     'authToken',
     'eventTracker',
     'coreUrl',

--- a/lib/kits/core/request.js
+++ b/lib/kits/core/request.js
@@ -6,16 +6,18 @@ function request(options = {}, callback) {
     let url = SGN.config.get('coreUrl') + (options.url ?? '');
     const method = options.method || 'get';
     const headers = options.headers ?? {};
-    const appKey = SGN.config.get('appKey');
+    const apiKey = SGN.config.get('apiKey');
     const clientVersion = SGN.config.get('clientVersion');
     const body = options.body;
 
-    if(!appKey) {
-        callback(new Error("`appKey` needs to be configured, please see README."))
+    if (!apiKey) {
+        callback(
+            new Error('`apiKey` needs to be configured, please see README')
+        );
         return;
     }
 
-    headers['X-Api-Key'] = appKey;
+    headers['X-Api-Key'] = apiKey;
 
     if (!headers['Accept']) {
         headers['Accept'] = 'application/json';

--- a/lib/kits/core/request.js
+++ b/lib/kits/core/request.js
@@ -10,6 +10,11 @@ function request(options = {}, callback) {
     const clientVersion = SGN.config.get('clientVersion');
     const body = options.body;
 
+    if(!appKey) {
+        callback(new Error("`appKey` needs to be configured, please see README."))
+        return;
+    }
+
     headers['X-Api-Key'] = appKey;
 
     if (!headers['Accept']) {

--- a/lib/sgn-sdk.js
+++ b/lib/sgn-sdk.js
@@ -28,11 +28,11 @@ SGN.CoreUIKit = CoreUIKit;
 
 SGN.config.bind('change', (changedAttributes) => {
     const newEventTracker = changedAttributes.eventTracker;
-    const newAppKey = changedAttributes.appKey;
+    const newApiKey = changedAttributes.apiKey;
     if (
-        (newAppKey || newEventTracker) &&
+        (newApiKey || newEventTracker) &&
         (newEventTracker || SGN.config.get('eventTracker'))?.trackId ===
-            (newAppKey || SGN.config.get('appKey'))
+            (newApiKey || SGN.config.get('apiKey'))
     ) {
         throw error(
             new Error(
@@ -59,12 +59,14 @@ if (isBrowser()) {
     const scriptEl = document.getElementById('sgn-sdk');
 
     if (scriptEl) {
-        const appKey = scriptEl.getAttribute('data-app-key');
+        const apiKey =
+            scriptEl.getAttribute('data-api-key') ||
+            scriptEl.getAttribute('data-app-key');
         const trackId = scriptEl.getAttribute('data-track-id');
         const config = {};
 
-        if (appKey) {
-            config.appKey = appKey;
+        if (apiKey) {
+            config.apiKey = apiKey;
         }
         if (trackId) {
             config.eventTracker = new SGN.EventsKit.Tracker({trackId});


### PR DESCRIPTION
As discussed at https://github.com/shopgun/TjekTeams/issues/57#issuecomment-818677971

This error is added at the same place the old `'Invalid API key.\nCould not find app matching your api key.'` error would have happened, when this was a backend requirement.