### PR TITLE
Traverse the DOM for data-link

### DIFF
--- a/examples/incito-publication.html
+++ b/examples/incito-publication.html
@@ -50,10 +50,9 @@
             });
 
             this.bootstrapper.fetch(function (error, res) {
-                console.log(error);
-                
                 if (error) {
-                    // Handle error.
+                    console.log(error);
+                    
                     return;
                 }
 

--- a/lib/incito-browser/incito.js
+++ b/lib/incito-browser/incito.js
@@ -12,6 +12,7 @@ import {
     getTextShadow,
     loadFonts
 } from './utils.js';
+import {closest} from '../util.js';
 
 export default class Incito extends MicroEvent {
     constructor(containerEl, {incito = {}}) {
@@ -76,9 +77,8 @@ export default class Incito extends MicroEvent {
 
     start() {
         this.el.addEventListener('click', (e) => {
-            const link = e.target.closest
-                ? e.target.closest('[data-link]').getAttribute('data-link')
-                : e.target.getAttribute('data-link');
+            const el = closest(e.target, '[data-link]');
+            const link = el ? el.dataset.link : null;
 
             if (isDefinedStr(link)) {
                 window.open(link, '_blank');

--- a/lib/incito-browser/incito.js
+++ b/lib/incito-browser/incito.js
@@ -77,7 +77,7 @@ export default class Incito extends MicroEvent {
 
     start() {
         this.el.addEventListener('click', (e) => {
-            const el = closest(e.target, '[data-link]');
+            const el = closest(e.target, '.incito__view [data-link]');
             const link = el ? el.dataset.link : null;
 
             if (isDefinedStr(link)) {

--- a/lib/incito-browser/incito.js
+++ b/lib/incito-browser/incito.js
@@ -76,7 +76,9 @@ export default class Incito extends MicroEvent {
 
     start() {
         this.el.addEventListener('click', (e) => {
-            const link = e.target.getAttribute('data-link');
+            const link = e.target.closest
+                ? e.target.closest('[data-link]').getAttribute('data-link')
+                : e.target.getAttribute('data-link');
 
             if (isDefinedStr(link)) {
                 window.open(link, '_blank');

--- a/lib/util.js
+++ b/lib/util.js
@@ -253,6 +253,21 @@ export function distance(lat1, lng1, lat2, lng2) {
     return dist;
 }
 
+export function closest(el, s) {
+    const matches =
+        Element.prototype.matches ||
+        Element.prototype.msMatchesSelector ||
+        Element.prototype.webkitMatchesSelector;
+
+    do {
+        if (matches.call(el, s)) return el;
+
+        el = el.parentElement || el.parentNode;
+    } while (el !== null && el.nodeType === 1);
+
+    return null;
+};
+
 // Method for wrapping a function that takes a callback in any position
 // to return promises if no callback is given in a call.
 // The second argument, cbParameterIndex, is the position of the callback in the original functions parameter list.


### PR DESCRIPTION
The issue was you could have a parent view with a link with a TextView inside. If you happened to click the TextView, the click handler wouldn't trigger as that target view didn't have the data-link attribute. Using closest(), we'll traverse upwards until we hit a data-link.