### PR TITLE
[Viewer] Minor styling fixes

### DIFF
--- a/examples/list-publications-template.html
+++ b/examples/list-publications-template.html
@@ -48,7 +48,7 @@
             data-component-publication-disable-global-scrollbar="false"
             data-component-publication-show-header-labels="true"
             data-component-publication-viewer-offer-click-behavior="overview_modal"
-            data-translation-keys--publication-viewer-download-button="Download newspaper"
+            data-translation-keys--publication-viewer-download-button="Download PDF"
             defer
         ></script>
 

--- a/examples/list-publications-template.html
+++ b/examples/list-publications-template.html
@@ -48,7 +48,7 @@
             data-component-publication-disable-global-scrollbar="false"
             data-component-publication-show-header-labels="true"
             data-component-publication-viewer-offer-click-behavior="overview_modal"
-            data-translation-keys--publication-viewer-download-button="Download Now"
+            data-translation-keys--publication-viewer-download-button="Download newspaper"
             defer
         ></script>
 

--- a/lib/kits/core-ui/components/common/header.styl
+++ b/lib/kits/core-ui/components/common/header.styl
@@ -60,14 +60,16 @@
                     animation-iteration-count 1
             
             &[data-show-labels="true"]
-                    > button
-                        width 66px
+                padding 4px 8px 2px
 
-                    .sgn__offer-shopping-list-counter
-                        margin-left 40px
+                > button
+                    width 66px
 
-                    .sgn__nav-label
-                        display block
+                .sgn__offer-shopping-list-counter
+                    margin-left 40px
+
+                .sgn__nav-label
+                    display block
 
         .sgn-pp__progress
             height 16px

--- a/lib/kits/core-ui/components/common/offer-overview.js
+++ b/lib/kits/core-ui/components/common/offer-overview.js
@@ -25,7 +25,7 @@ const defaultTemplate = `\
         <div class="sgn-popup-content">
             <div class="sgn-popup-offer-container">
                 <div class="sgn-offer-img">
-                    <img src="{{images.view}}" alt="{{heading}}">
+                    <img src="{{images.zoom}}" alt="{{heading}}">
                 </div>
                 <div class="sgn-offer-texts-container">
                     <div class="sgn-offer-heading">
@@ -115,7 +115,7 @@ const OfferOverview = ({
                 offer?.currency_code || currency
             ),
             images: {
-                view: offer?.images?.[0]?.url
+                zoom: offer?.images?.[0]?.url
             },
             from: formatDate(offer?.validity?.from, translations.localeCode, {
                 dateStyle: 'full'

--- a/lib/kits/core-ui/components/incito-publication/main-container.styl
+++ b/lib/kits/core-ui/components/incito-publication/main-container.styl
@@ -65,6 +65,7 @@
             top calc(100% - 4px)
             margin-bottom -4px
             width 100%
+            height 4px
             z-index 99
             text-align center
             color #ffffff
@@ -75,6 +76,7 @@
             background rgba(0,0,0,0.3)
             left 50%
             width auto
+            height 16px
             padding 6px 18px
             font-size 14px
             border-radius 6px

--- a/lib/kits/core-ui/components/paged-publication/main-container.styl
+++ b/lib/kits/core-ui/components/paged-publication/main-container.styl
@@ -52,5 +52,8 @@
             .sgn-pp__control
                 display none
 
+            .verso__scroller
+                bottom 20px
+
 .sgn-clearfix
     clear both

--- a/lib/kits/core-ui/components/paged-publication/main-container.styl
+++ b/lib/kits/core-ui/components/paged-publication/main-container.styl
@@ -52,8 +52,5 @@
             .sgn-pp__control
                 display none
 
-            .verso__scroller
-                bottom 20px
-
 .sgn-clearfix
     clear both

--- a/lib/kits/core-ui/incito-publication.js
+++ b/lib/kits/core-ui/incito-publication.js
@@ -233,6 +233,11 @@ const IncitoPublication = (
     };
 
     const addScrollListener = () => {
+        const isContainerFixed =
+            window.getComputedStyle(options.el).position === 'fixed';
+        const progressContainer = options.el.querySelector(
+            '.sgn-incito__scroll-progress'
+        );
         const progressBar = options.el.querySelector(
             '.sgn-incito__scroll-progress-bar'
         );
@@ -240,7 +245,7 @@ const IncitoPublication = (
             '.sgn-incito__scroll-progress-text'
         );
 
-        if (progressText) {
+        if (progressText && isContainerFixed) {
             progressText.innerHTML = '0%';
 
             options.el.addEventListener('scroll', () => {
@@ -249,6 +254,8 @@ const IncitoPublication = (
                 progressBar.style.transform = `scaleX(${scrollValue / 100})`;
                 progressText.innerHTML = `${Math.round(scrollValue)}%`;
             });
+        } else {
+            progressContainer?.parentNode?.removeChild(progressContainer);
         }
     };
 

--- a/locales/en_US.js
+++ b/locales/en_US.js
@@ -4,7 +4,7 @@ export default {
     publication_viewer_shopping_list_clear_button: 'Clear list',
     publication_viewer_delete_crossed_out_button: 'Delete crossed out items',
     publication_viewer_print_button: 'Print',
-    publication_viewer_download_button: 'Download',
+    publication_viewer_download_button: 'Download PDF',
     publication_viewer_until_label: 'Through',
     publication_viewer_pages_button: 'Pages',
     publication_viewer_offers_button: 'Offers',


### PR DESCRIPTION
## Feedback to SDK


Mobile:
1. It cuts the picture
2. Under 'Overview' à 'Pages' here, the pages are not displayed - only numbers are shown

General (mobile + web) :
3. 'Download' does not work.
    Mobile phone:
        It also cuts the image in the downloaded version
        It does not retrieve all pages
4. 'Download' should be called 'Download newspaper'


The following must also be corrected - but not necessarily before we go live

Mobile phone:
5. The navigation arrows are not visible in the mobile version.
 
General (mobile + web) :
6. Search: right now you have to search for specific words for the search to appear. For example. here with 'Nutella'
7. Click on offer: by clicking on the offer, the image of the item does not get bigger. The item is pictured with the same size when you see it in the newspaper as when you click on the offer to see more / clearer.

Web:
8. Share: We first shared the inlet list, but got these two bugs. Is it because this is a test version?




## Observations:
### Based on JsFiddle and local version comparison via browserstack (mobile)
1. Related to JsFiddle - the browser's toolbar blocks the bottom part of the page in jsfiddle
2. Related to JsFiddle limitations
3. Related to JsFiddle limitations
4. Can be fixed via `data-translation-keys--publication-viewer-download-button="Download newspaper"`
5. Working as expected. Shall we show them even on mobile?
6. Working as expected - API limitations?
7. Valid - Fixed in this PR
8. Related to JsFiddle limitations

