### PR TITLE
Add filter on viewer level

### DIFF
--- a/lib/kits/core-ui/components/helpers/transformers.ts
+++ b/lib/kits/core-ui/components/helpers/transformers.ts
@@ -34,6 +34,8 @@ export const transformScriptData = (
         disablePageDecorations:
             dataset.componentPublicationDisablePagedecorations === 'true',
         showHeaderLabels:
-            dataset.componentPublicationShowHeaderLabels === 'true'
+            dataset.componentPublicationShowHeaderLabels === 'true',
+        requestFilter: dataset.componentListPublicationsRequestFilter,
+        clientFilter: dataset.componentListPublicationsClientFilter
     };
 };

--- a/lib/kits/core-ui/incito-publication.ts
+++ b/lib/kits/core-ui/incito-publication.ts
@@ -11,6 +11,7 @@ import MenuPopup from './components/common/menu-popup';
 import OfferOverview from './components/common/offer-overview';
 import ShoppingList from './components/common/shopping-list';
 import {transformScriptData} from './components/helpers/transformers';
+import {transformFilter} from './components/helpers/component';
 import MainContainer from './components/incito-publication/main-container';
 
 const IncitoPublication = (
@@ -326,9 +327,16 @@ const IncitoPublication = (
                     dealer_id: scriptEls.businessId,
                     order_by: '-publication_date',
                     types: 'incito',
-                    limit: 1
+                    limit: 24,
+                    ...transformFilter(scriptEls.requestFilter)
                 }
             })
+        )?.filter((publication) =>
+            Object.entries(transformFilter(scriptEls.clientFilter)).reduce(
+                (prev, {0: key, 1: value}) =>
+                    publication[key] === value && prev,
+                {}
+            )
         )?.[0]?.id;
 
     const fetchOffer = async ({viewId, publicationId}) => {

--- a/lib/kits/core-ui/list-publications.ts
+++ b/lib/kits/core-ui/list-publications.ts
@@ -32,8 +32,6 @@ const ListPublications = (
             scriptEl.dataset.componentListPublicationsContainer ||
             mainContainer,
         orderBy: scriptEl.dataset.componentListPublicationsOrderBy,
-        requestFilter: scriptEl.dataset.componentListPublicationsRequestFilter,
-        clientFilter: scriptEl.dataset.componentListPublicationsClientFilter,
         preferredViewer:
             scriptEl.dataset.componentPublicationsViewerPreferredType
     };

--- a/lib/kits/core-ui/paged-publication.ts
+++ b/lib/kits/core-ui/paged-publication.ts
@@ -10,7 +10,8 @@ import OfferOverview from './components/common/offer-overview';
 import {
     translate,
     pushQueryParam,
-    getHashFragments
+    getHashFragments,
+    transformFilter
 } from './components/helpers/component';
 import {transformScriptData} from './components/helpers/transformers';
 import MainContainer from './components/paged-publication/main-container';
@@ -323,9 +324,17 @@ const PagedPublication = (
                 qs: {
                     dealer_id: scriptEls.businessId,
                     order_by: '-publication_date',
-                    limit: 1
+                    types: 'paged',
+                    limit: 24,
+                    ...transformFilter(scriptEls.requestFilter)
                 }
             })
+        )?.filter((publication) =>
+            Object.entries(transformFilter(scriptEls.clientFilter)).reduce(
+                (prev, {0: key, 1: value}) =>
+                    publication[key] === value && prev,
+                {}
+            )
         )?.[0]?.id;
 
     const dispatchPublicationData = () => {


### PR DESCRIPTION
Currently, both `data-component-list-publications-request-filter` and `data-component-list-publications-client-filter` options which are used for filtering the publications only work on `list-publications`. 
However, some clients would also like to use the filter option in their publication viewer instead of just displaying their latest publication.