### PR TITLE
fix(CoreUI transformIncitoOffer): Handle V4 validity range

### DIFF
--- a/lib/kits/core-ui/components/common/offer-overview.ts
+++ b/lib/kits/core-ui/components/common/offer-overview.ts
@@ -151,13 +151,16 @@ const OfferOverview = ({
             },
             dateRange: getDateRange(
                 offer?.validity?.from,
-                offer?.validity?.to,
+                new Date(Number(parseDateStr(offer?.validity?.to)) - 1000).toISOString(),
                 'publication_viewer_offer_date_range'
             ),
-            status: getPubState(offer?.validity?.from, offer?.validity?.to),
+            status: getPubState(
+                offer?.validity?.from,
+                new Date(Number(parseDateStr(offer?.validity?.to)) - 1000).toISOString(),
+            ),
             statusMessage: getPubStateMessage(
                 offer?.validity?.from,
-                offer?.validity?.to
+                new Date(Number(parseDateStr(offer?.validity?.to)) - 1000).toISOString(),
             )
         };
     };

--- a/lib/kits/core-ui/components/common/offer-overview.ts
+++ b/lib/kits/core-ui/components/common/offer-overview.ts
@@ -6,7 +6,8 @@ import {
     translate,
     getDateRange,
     getPubState,
-    getPubStateMessage
+    getPubStateMessage,
+    parseDateStr
 } from '../helpers/component';
 import {request, V2Offer} from '../../../core';
 import './offer-overview.styl';


### PR DESCRIPTION
@jrlarano I suggest moving forward we try to parse dates as early as possible(i.e. immediately after fetching) instead of passing around string dates that are tedious to modify for purpose(as seen here).