### PR TITLE
perf(browserslist): Drop IE11 support

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -11,20 +11,9 @@
         "setPublicClassFields": true,
         "superIsCallableConstructor": true
     },
-    "targets": {"browsers": ["> 3%", "IE 11"], "node": 10},
-    "presets": [
-        [
-            "@babel/preset-env",
-            {
-                "targets": {"browsers": ["> 3%", "IE 11"], "node": 10},
-                "corejs": 3,
-                "useBuiltIns": "usage",
-                "exclude": ["transform-typeof-symbol"]
-            }
-        ]
-    ],
+    "presets": ["@babel/preset-env"],
     "plugins": [
         "@babel/plugin-syntax-import-assertions",
-        ["@babel/plugin-transform-runtime", {"corejs": 3}]
+        "@babel/plugin-transform-runtime"
     ]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
     "description": "Tjek SDK for JavaScript.",
     "type": "module",
+    "browserslist": "supports css-grid",
     "main": "dist/shopgun-sdk/sgn-sdk.cjs.js",
     "browser": "dist/shopgun-sdk/sgn-sdk.js",
     "module": "dist/shopgun-sdk/sgn-sdk.es.js",
@@ -8,11 +9,11 @@
     "bundlesize": [
         {
             "path": "./dist/shopgun-sdk/sgn-sdk.js",
-            "maxSize": "185 kB"
+            "maxSize": "85 kB"
         },
         {
             "path": "./dist/shopgun-sdk/sgn-sdk.min.js",
-            "maxSize": "100 kB"
+            "maxSize": "55 kB"
         },
         {
             "path": "./dist/shopgun-sdk/sgn-sdk.cjs.js",
@@ -24,11 +25,11 @@
         },
         {
             "path": "./dist/incito-browser/incito.js",
-            "maxSize": "90 kB"
+            "maxSize": "20 kB"
         },
         {
             "path": "./dist/incito-browser/incito.min.js",
-            "maxSize": "45 kB"
+            "maxSize": "15 kB"
         },
         {
             "path": "./dist/incito-browser/incito.cjs.js",
@@ -40,19 +41,19 @@
         },
         {
             "path": "./dist/verso-browser/verso.js",
-            "maxSize": "75 kB"
+            "maxSize": "25 kB"
         },
         {
             "path": "./dist/verso-browser/verso.min.js",
-            "maxSize": "35 kB"
+            "maxSize": "15 kB"
         },
         {
             "path": "./dist/verso-browser/verso.cjs.js",
-            "maxSize": "30 kB"
+            "maxSize": "20 kB"
         },
         {
             "path": "./dist/verso-browser/verso.es.js",
-            "maxSize": "25 kB"
+            "maxSize": "20 kB"
         },
         {
             "path": "./dist/tjek-sdk/index.cjs.js",


### PR DESCRIPTION
# Effective change

Remove aggressive automatic polyfill adding and increase browserslist support level to `supports css-grid`, giving us this base level of browser support: https://caniuse.com/css-grid

# Impact

This reduces the size of our main, largest build targets by half! `sgn-sdk-4.x.x.min.js` going from 

# Background

The `list-publications` component has actually already required CSS Grid support for over a year now, of which we have(to my knowledge) heard any complaints. With this in mind I feel comfortable increasing our minimum browser support limit on the SDK to effectively be: 
- Chrome 57 (Mar 9 2017)
- Safari 10.1 (Mar 27 2017)
- Firefox 54 (Mar 21 2017)
- Safari iOS 10.3 (Mar 27 2017)

# Risks

This is in principle a breaking change, dropping off 0.5% of Danish internet users according to GS: https://gs.statcounter.com/browser-market-share/all/denmark/#monthly-202201-202301

But I don't think we are interested in considering this a breaking change in terms of going from 4.x.x to 5.x.x as that would mean verifying and updating a dozen existing integration. This is also not a breaking change in terms of the APIs offered by the SDK. 