### PR TITLE
Feat/set lazyload in constructor

### DIFF
--- a/lib/incito-browser/incito.ts
+++ b/lib/incito-browser/incito.ts
@@ -246,7 +246,10 @@ function renderView(view, canLazyload) {
             const src = String(new URL(view.src));
 
             if (isDefinedStr(view.src)) {
-                attrs.loading = 'lazy';
+                if (canLazyload) {
+                    attrs.loading = 'lazy';
+                }
+
                 attrs.src = src;
             }
 

--- a/lib/incito-browser/incito.ts
+++ b/lib/incito-browser/incito.ts
@@ -682,7 +682,7 @@ export default class Incito extends MicroEvent<{
     videoObserver: IntersectionObserver;
     sectionObserver: IntersectionObserver;
     sectionVisibility: Map<HTMLElement, boolean>;
-    constructor(containerEl: HTMLElement, {incito, canLazyload}: {incito: IIncito, canLazyload: boolean}) {
+    constructor(containerEl: HTMLElement, {incito, canLazyload}: {incito: IIncito, canLazyload?: boolean}) {
         super();
 
         this.containerEl = containerEl;

--- a/lib/incito-browser/incito.ts
+++ b/lib/incito-browser/incito.ts
@@ -682,7 +682,7 @@ export default class Incito extends MicroEvent<{
     videoObserver: IntersectionObserver;
     sectionObserver: IntersectionObserver;
     sectionVisibility: Map<HTMLElement, boolean>;
-    constructor(containerEl: HTMLElement, {incito}: {incito: IIncito}) {
+    constructor(containerEl: HTMLElement, {incito, canLazyload}: {incito: IIncito, canLazyload: boolean}) {
         super();
 
         this.containerEl = containerEl;
@@ -690,7 +690,7 @@ export default class Incito extends MicroEvent<{
         this.el = document.createElement('div');
         this.ids = {};
         this.sections = [];
-        this.canLazyload = 'IntersectionObserver' in window;
+        this.canLazyload = canLazyload || 'IntersectionObserver' in window;
         this.render();
     }
 

--- a/lib/incito-browser/incito.ts
+++ b/lib/incito-browser/incito.ts
@@ -682,7 +682,7 @@ export default class Incito extends MicroEvent<{
     videoObserver: IntersectionObserver;
     sectionObserver: IntersectionObserver;
     sectionVisibility: Map<HTMLElement, boolean>;
-    constructor(containerEl: HTMLElement, {incito}: {incito: IIncito}) {
+    constructor(containerEl: HTMLElement, {incito, canLazyload}: {incito: IIncito, canLazyload: boolean}) {
         super();
 
         this.containerEl = containerEl;
@@ -690,7 +690,7 @@ export default class Incito extends MicroEvent<{
         this.el = document.createElement('div');
         this.ids = {};
         this.sections = [];
-        this.canLazyload = 'IntersectionObserver' in window;
+        this.canLazyload = canLazyload !== undefined ? canLazyload : 'IntersectionObserver' in window;
         this.render();
     }
 


### PR DESCRIPTION
To improve the performance and reliability of generating image based previews of an Incito (archive), I would like to be able to manually disable lazy-loading when rendering an Incito preview as that allows me to await `networkIdle` in puppeteer instead of simulating scrolling down the page to trigger image loading.