### PR TITLE
fix(PagedPublicationEventTracking): avoid retracking current position

### DIFF
--- a/lib/kits/paged-publication/event-tracking.ts
+++ b/lib/kits/paged-publication/event-tracking.ts
@@ -66,7 +66,7 @@ class PagedPublicationEventTracking extends MicroEvent {
     };
 
     afterNavigation = (e) => {
-        this.pageSpreadAppeared(e.pageSpread);
+        this.pageSpreadAppeared(e.pageSpread, e.verso);
     };
 
     attemptedNavigation = (e) => {
@@ -77,14 +77,19 @@ class PagedPublicationEventTracking extends MicroEvent {
         if (e.scale === 1) this.pageSpreadDisappeared();
     };
 
-    pageSpreadAppeared(pageSpread: PagedPublicationPageSpread) {
+    pageSpreadAppeared(
+        pageSpread: PagedPublicationPageSpread,
+        verso?: {newPosition: number; previousPosition: number}
+    ) {
         if (pageSpread && this.hidden) {
             this.pageSpread = pageSpread;
             this.hidden = false;
 
-            this.trackPageSpreadAppeared(
-                pageSpread.getPages().map((page) => page.pageNumber)
-            );
+            if (verso && verso.newPosition !== verso.previousPosition) {
+                this.trackPageSpreadAppeared(
+                    pageSpread.getPages().map((page) => page.pageNumber)
+                );
+            }
         }
     }
 


### PR DESCRIPTION
There are a lot of levels this could be fixed. I tried fixing this at the Verso level, but some features of the viewer rely on navigation to the current pageId to force a rerender(for example when switching single/dual mode in response to viewport size changes). I decided to do it just at the event tracking, as that is the actual problem we're solving anyway.

fixes #188