### PR TITLE
[Integration] Use semicolon delimiter if exists

### DIFF
--- a/lib/kits/core-ui/components/helpers/component.ts
+++ b/lib/kits/core-ui/components/helpers/component.ts
@@ -190,8 +190,10 @@ export const translate = (key = '', view = {}) => {
     return Mustache.render(template, view);
 };
 
-export const transformFilter = (filter) =>
-    (filter || '')?.split(',').reduce((queries, filter) => {
+export const transformFilter = (filter) => {
+    const delimiter = filter?.includes(';') ? ';' : ',';
+
+    return (filter || '')?.split(delimiter).reduce((queries, filter) => {
         const {0: key, 1: val} = filter.split(':');
 
         if (key) {
@@ -201,6 +203,7 @@ export const transformFilter = (filter) =>
 
         return queries;
     }, {});
+};
 
 export const getColorBrightness = (color) => {
     color = color.replace('#', '');


### PR DESCRIPTION
This is to support the filtering of multiple tags
eg:
```
data-component-list-publications-request-filter="tags:tag1,tag2;"
```