### PR TITLE
fix: modal title style

### DIFF
--- a/lib/kits/core-ui/components/common/offer-overview.styl
+++ b/lib/kits/core-ui/components/common/offer-overview.styl
@@ -219,7 +219,7 @@
             max-width 476px
             font-weight 600
             font-size 1.2rem
-            padding-bottom 0.2rem
+            margin-bottom 0.2rem
             display -webkit-box
             -webkit-box-orient vertical
             -webkit-line-clamp 2
@@ -367,13 +367,9 @@
 
                             .sgn-product-title
                                 font-size 0.833rem
-                                white-space normal
-                                overflow visible
 
                             .sgn-product-description
                                 font-size 0.833rem
-                                white-space normal
-                                overflow visible
 
                         .sgn-product-price-container
                             flex-direction column-reverse


### PR DESCRIPTION
Before: 
![image](https://github.com/user-attachments/assets/cfce3a66-13a5-4553-81fa-2d875992a164)


After: 
![image](https://github.com/user-attachments/assets/4f77f474-0d5c-4f6d-bba1-5b79844aaf61)
