### PR TITLE
Cleanup savings template

### DIFF
--- a/lib/kits/core-ui/components/common/offer-overview.ts
+++ b/lib/kits/core-ui/components/common/offer-overview.ts
@@ -204,6 +204,7 @@ const OfferOverview = ({
 
             return {
                 ...product,
+                description: product.description?.replace('{{savings}}', ''),
                 link: product.link || offer.webshop_link,
                 price,
                 formattedPrice: formatPrice(price, localeCode, priceCurrency),


### PR DESCRIPTION
This is to avoid the `{{savings}}` template text from showing up in the modal. The reason why there's `{{savings}}` is because we use this as template text for `comment` component which will be tranformed by bumblebee into `Spar {savingsVal}`. However, the squid returns this as it is.

![image](https://github.com/user-attachments/assets/0ec24c26-3954-4e64-89c0-d90b8e7a4d92)
