### PR TITLE
fix(incito): almost respect VideoView autoplay/controls/loop options

### DIFF
--- a/lib/incito-browser/incito.ts
+++ b/lib/incito-browser/incito.ts
@@ -305,7 +305,17 @@ function renderView(view, canLazyload: boolean, shouldLazyload: boolean) {
                 }
             } else {
                 attrs.src = `${src}#t=0.1`;
-                attrs.controls = '';
+                if (view.autoplay === true) {
+                    attrs['data-autoplay'] = true;
+                }
+
+                if (view.controls === true) {
+                    attrs['controls'] = '';
+                }
+
+                if (view.loop === true) {
+                    attrs['loop'] = '';
+                }
             }
 
             break;

--- a/lib/incito-browser/incito.ts
+++ b/lib/incito-browser/incito.ts
@@ -287,35 +287,24 @@ function renderView(view, canLazyload: boolean, shouldLazyload: boolean) {
 
             const src = String(new URL(view.src));
 
+            if (view.autoplay === true) {
+                attrs['data-autoplay'] = true;
+            }
+
+            if (view.controls === true) {
+                attrs['controls'] = '';
+            }
+
+            if (view.loop === true) {
+                attrs['loop'] = '';
+            }
+
             if (canLazyload && shouldLazyload) {
                 attrs['data-src'] = `${src}#t=0.1`;
                 attrs['data-mime'] = view.mime;
                 classNames.push('incito--lazy');
-
-                if (view.autoplay === true) {
-                    attrs['data-autoplay'] = true;
-                }
-
-                if (view.controls === true) {
-                    attrs['controls'] = '';
-                }
-
-                if (view.loop === true) {
-                    attrs['loop'] = '';
-                }
             } else {
                 attrs.src = `${src}#t=0.1`;
-                if (view.autoplay === true) {
-                    attrs['data-autoplay'] = true;
-                }
-
-                if (view.controls === true) {
-                    attrs['controls'] = '';
-                }
-
-                if (view.loop === true) {
-                    attrs['loop'] = '';
-                }
             }
 
             break;


### PR DESCRIPTION
There is an issue with the video template, that some of the videos are registered as lazyload and others not within the same publication. 

E.g. here https://www.stark.gl/brochurer/tilbudsavis

Reagardless of the lazyload detection issue, would it not make sense to respect the attributes set on the video view? 