### PR TITLE
Fix close btn mobile position

### DIFF
--- a/lib/kits/core-ui/components/common/sidebar.styl
+++ b/lib/kits/core-ui/components/common/sidebar.styl
@@ -52,7 +52,7 @@
             top 0
             opacity 0.5
             z-index 99
-            margin 18px 10px
+            margin 18px
             
             &:hover,
             &:active
@@ -313,6 +313,12 @@
                 width unset !important
                 margin-left unset!important
 
+    &[data-component-template-sidebar-position="left"]
+        .sgn__nav-content-mobile
+            > .sgn__close-publication
+                left unset !important
+                right 0 !important
+
     .sgn__nav-content-mobile
         display block
 
@@ -325,7 +331,7 @@
             position absolute
             top 0
             left 0
-            margin 18px 10px
+            margin 18px
             z-index 99
             color inherit
             vertical-align middle


### PR DESCRIPTION
Relates to: https://linear.app/tjek/issue/OPS-20/menu-button-in-sdk-positioned-incorrectly